### PR TITLE
Puts name and address in other iNovah fields

### DIFF
--- a/server/services/INovah.js
+++ b/server/services/INovah.js
@@ -74,6 +74,7 @@ type PaymentIn = {|
   PaymentCode: string,
   PaymentAllocation: PaymentAllocationIn,
   LastName?: string,
+  StreetName?: string,
   City?: string,
   State?: string,
   Zip?: string,
@@ -384,6 +385,7 @@ export default class INovah {
   async addTransaction(
     registryOrderId: string,
     stripeChargeId: string,
+    stripeTransactionId: string,
     { quantity, amountInDollars, unitPriceInDollars }: TransactionPayment,
     {
       cardholderName,
@@ -408,7 +410,7 @@ export default class INovah {
           ForeignID:
             process.env.SKIP_IDEMPOTENCY_CHECKS === '0'
               ? undefined
-              : stripeChargeId,
+              : stripeTransactionId,
           Payment: {
             PaymentCode: 'REG13',
             PaymentAllocation: {
@@ -418,6 +420,8 @@ export default class INovah {
               UnitCharge: unitPriceInDollars.toString(),
             },
             Invoice: registryOrderId,
+            LastName: cardholderName,
+            StreetName: billingAddress1,
             City: billingCity,
             State: billingState,
             Zip: billingZip,

--- a/server/services/INovah.test.js
+++ b/server/services/INovah.test.js
@@ -229,6 +229,7 @@ describe('INovah', () => {
         inovah.addTransaction(
           'REG-DC-20171214-abcd123',
           'chg_testcharge',
+          'txn_testtxn',
           {
             amountInDollars: 28.0,
             unitPriceInDollars: 14.0,

--- a/server/stripe-events.js
+++ b/server/stripe-events.js
@@ -47,6 +47,7 @@ async function processChargeSucceeded(
   } = await inovah.addTransaction(
     charge.metadata['order.orderId'] || 'unknown',
     charge.id,
+    balanceTransaction.id,
     {
       // Stripe works in cents, iNovah in floating-point dollars.
       amountInDollars: balanceTransaction.net / 100,
@@ -89,10 +90,12 @@ export async function processStripeEvent(
     ? deps.stripe.webhooks.constructEvent(body, webhookSignature, webhookSecret)
     : JSON.parse(body);
 
-  console.log(
-    'STRIPE WEBHOOK: ',
-    JSON.stringify({ ...event, data: 'REDACTED' })
-  );
+  if (process.env['NODE_ENV'] !== 'test') {
+    console.log(
+      'STRIPE WEBHOOK: ',
+      JSON.stringify({ ...event, data: 'REDACTED' })
+    );
+  }
 
   switch (event.type) {
     case 'charge.succeeded':

--- a/server/stripe-events.test.js
+++ b/server/stripe-events.test.js
@@ -48,6 +48,7 @@ describe('processStripeEvent', () => {
       expect(inovah.addTransaction).toHaveBeenCalledWith(
         'DC-20171215-yg4lk',
         'ch_00000000000000',
+        'txn_1BYfsgHEIqCf0Nlg2VWuyvMI',
         {
           amountInDollars: 14.0,
           quantity: 1,


### PR DESCRIPTION
These fields aren't semantically quite right but they display more
prominently in the UI.

Also changes to use the balance transaction ID for the foreign key for
idempotency and removes logging during test.